### PR TITLE
Clarify standard array docstring

### DIFF
--- a/src/decoders/standardarray.py
+++ b/src/decoders/standardarray.py
@@ -81,7 +81,7 @@ class StandardArrayDecoder(Decoder):
         return leaders
 
     def _build_standard_array(self):
-        """Return list of cosets: each is list of codewords shifted by leader."""
+        """Return a list of cosets; each is a list of codewords shifted by its leader."""
         p = self.p
         cosets = []
         for leader in self.coset_leaders:


### PR DESCRIPTION
## Summary
- Clarify wording of `_build_standard_array` docstring for precision

## Testing
- `pytest` *(fails: BCHCode.__init__() missing argument `prim_poly`)*

------
https://chatgpt.com/codex/tasks/task_e_689cc7e06294832ea61b81108fbf5917